### PR TITLE
Publish package to npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,6 +1,7 @@
 name: Publish to npm
 on:
-  push
+  release:
+    types: [published]
 jobs:
   publish-npm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR implements a GitHub action for publishing the package to npm, after a release is published on GitHub.