### PR TITLE
Change errors to warns

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,39 +9,36 @@ module.exports = {
   extends: "react-app",
   plugins: ["import", "react-hooks", "prettier"],
   rules: {
-    "no-dupe-keys": "error",
-    "no-undef": "error",
-    "no-unreachable": "error",
+    "no-dupe-keys": "warn",
+    "no-undef": "warn",
+    "no-unreachable": "warn",
     "no-unused-vars": [
-      "error",
+      "warn",
       {
         argsIgnorePattern: "^_",
         varsIgnorePattern: "^_",
         ignoreRestSiblings: true
       }
     ],
-    "no-useless-constructor": "error",
-    "no-var": "error",
-    "no-duplicate-imports": "error",
-    "no-duplicate-case": "error",
-    "import/no-unresolved": "error",
-    "import/default": "error",
-    "react/jsx-no-undef": "error",
-    "react/jsx-uses-vars": "error",
-    "react/jsx-uses-react": "error",
-    "react/react-in-jsx-scope": "error",
-    "react/no-string-refs": "error",
-    "react/prop-types": ["error", { skipUndeclared: true }],
-    "react/forbid-prop-types": "error",
-    "react/prefer-stateless-function": [
-      "error",
-      { ignorePureComponents: true }
-    ],
-    "react-hooks/rules-of-hooks": "error", // Checks rules of Hooks
+    "no-useless-constructor": "warn",
+    "no-var": "warn",
+    "no-duplicate-imports": "warn",
+    "no-duplicate-case": "warn",
+    "import/no-unresolved": "warn",
+    "import/default": "warn",
+    "react/jsx-no-undef": "warn",
+    "react/jsx-uses-vars": "warn",
+    "react/jsx-uses-react": "warn",
+    "react/react-in-jsx-scope": "warn",
+    "react/no-string-refs": "warn",
+    "react/prop-types": ["warn", { skipUndeclared: true }],
+    "react/forbid-prop-types": "warn",
+    "react/prefer-stateless-function": ["warn", { ignorePureComponents: true }],
+    "react-hooks/rules-of-hooks": "warn", // Checks rules of Hooks
     "react-hooks/exhaustive-deps": "warn", // Checks effect dependencies
-    "prettier/prettier": "error",
-    "no-console": ["error", { "allow": ["warn", "error"] }],
-    "no-debugger": "error"
+    "prettier/prettier": "warn",
+    "no-console": ["warn", { allow: ["warn", "error"] }],
+    "no-debugger": "warn"
   }
 };
 


### PR DESCRIPTION
1. We depend on `eslint-config-react-app`.
2. `eslint-config-react-app` uses _only_ warnings but we want errors all the time.
3. Because overriding `eslint-config-react-app` at all times would be costly and would defeat the purpose on depending on it, we decided to _not_ do it and rather make our tools to **treat warnings as errors**.
4. Having warnings and errors mixed in can be a bad experience since they would behave like the same and just cause some visual confusion.
5. So, changing all errors to be warnings seems like a good idea.