### PR TITLE
Add proper version of eslint-plugin-flowtype and eslint-plugin-react-hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ableco/eslint-config",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "ESLint configuration from https://github.com/ableco/coding-standards",
   "main": "index.js",
   "repository": "https://github.com/ableco/eslint-config",
@@ -10,11 +10,12 @@
     "babel-eslint": "^10.0.3",
     "eslint": "^6.5.1",
     "eslint-config-react-app": "^5.0.2",
+    "eslint-plugin-flowtype": "^3.13.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.16.0",
-    "eslint-plugin-react-hooks": "^2.1.1",
+    "eslint-plugin-react-hooks": "^1.7.0",
     "eslint-utils": "^1.4.2",
     "prettier": "^1.18.2"
   }


### PR DESCRIPTION
Added `eslint-plugin-flowtype` because, while we're not using it, installing is harmless and it will save us to bump to another version in case some project decide to use it (and it saves us a warning in the log).

Also changed version for `eslint-plugin-react-hooks` to `^1.7.0` since that's the version used for `eslint-config-react-app`.