### PR TITLE
Remove eslint extends

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,39 +6,41 @@ module.exports = {
     jest: true
   },
   parser: "babel-eslint",
-  extends: "react-app",
-  plugins: ["import", "react-hooks", "prettier"],
+  plugins: ["import", "react", "react-hooks", "prettier"],
   rules: {
-    "no-dupe-keys": "warn",
-    "no-undef": "warn",
-    "no-unreachable": "warn",
+    "no-dupe-keys": "error",
+    "no-undef": "error",
+    "no-unreachable": "error",
     "no-unused-vars": [
-      "warn",
+      "error",
       {
         argsIgnorePattern: "^_",
         varsIgnorePattern: "^_",
         ignoreRestSiblings: true
       }
     ],
-    "no-useless-constructor": "warn",
-    "no-var": "warn",
-    "no-duplicate-imports": "warn",
-    "no-duplicate-case": "warn",
-    "import/no-unresolved": "warn",
-    "import/default": "warn",
-    "react/jsx-no-undef": "warn",
-    "react/jsx-uses-vars": "warn",
-    "react/jsx-uses-react": "warn",
-    "react/react-in-jsx-scope": "warn",
-    "react/no-string-refs": "warn",
-    "react/prop-types": ["warn", { skipUndeclared: true }],
-    "react/forbid-prop-types": "warn",
-    "react/prefer-stateless-function": ["warn", { ignorePureComponents: true }],
-    "react-hooks/rules-of-hooks": "warn", // Checks rules of Hooks
-    "react-hooks/exhaustive-deps": "warn", // Checks effect dependencies
-    "prettier/prettier": "warn",
-    "no-console": ["warn", { allow: ["warn", "error"] }],
-    "no-debugger": "warn"
+    "no-useless-constructor": "error",
+    "no-var": "error",
+    "no-duplicate-imports": "error",
+    "no-duplicate-case": "error",
+    "import/no-unresolved": "error",
+    "import/default": "error",
+    "react/jsx-no-undef": "error",
+    "react/jsx-uses-vars": "error",
+    "react/jsx-uses-react": "error",
+    "react/react-in-jsx-scope": "error",
+    "react/no-string-refs": "error",
+    "react/prop-types": ["error", { skipUndeclared: true }],
+    "react/forbid-prop-types": "error",
+    "react/prefer-stateless-function": [
+      "error",
+      { ignorePureComponents: true }
+    ],
+    "react-hooks/rules-of-hooks": "error", // Checks rules of Hooks
+    "react-hooks/exhaustive-deps": "error", // Checks effect dependencies
+    "prettier/prettier": "error",
+    "no-console": ["error", { allow: ["warn", "error"] }],
+    "no-debugger": "error"
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -9,13 +9,10 @@
   "dependencies": {
     "babel-eslint": "^10.0.3",
     "eslint": "^6.5.1",
-    "eslint-config-react-app": "^5.0.2",
     "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-react-hooks": "^2.1.1",
-    "eslint-utils": "^1.4.2",
     "prettier": "^1.18.2"
   }
 }


### PR DESCRIPTION
1. Errors are errors again.
2. `eslint-config-react-app` is no longer the base.
3. Removed `eslint-config-react-app` peer deps.

@hpneo Should we change the version and release?