### PR TITLE
Move ESLint and Prettier to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,19 @@
   "repository": "https://github.com/ableco/eslint-config",
   "author": "Able",
   "license": "MIT",
+  "peerDependencies": {
+    "eslint": "^6.0.0",
+    "prettier": "^1.18.0"
+  },
   "dependencies": {
     "babel-eslint": "^10.0.3",
-    "eslint": "^6.5.1",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.16.0",
-    "eslint-plugin-react-hooks": "^2.1.1",
+    "eslint-plugin-react-hooks": "^2.1.1"
+  },
+  "devDependencies": {
+    "eslint": "^6.5.1",
     "prettier": "^1.18.2"
   }
 }


### PR DESCRIPTION
The recommended configuration to distribute shareable configurations is
to place "eslint" under "peerDependencies" [1].

Same as prettier. The config users are responsible for installing both.

[1] https://eslint.org/docs/developer-guide/shareable-configs#publishing-a-shareable-config