### PR TITLE
Update to with @babel/eslint-parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
     es6: true,
     jest: true,
   },
-  parser: "babel-eslint",
+  parser: "@babel/eslint-parser",
   extends: ["plugin:unicorn/recommended"],
   plugins: ["import", "react", "react-hooks", "prettier", "unicorn"],
   rules: {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prettier": "^2.4.1"
   },
   "dependencies": {
-    "babel-eslint": "^10.1.0",
+    "@babel/eslint-parser": "^7.16.0",
     "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.26.1",


### PR DESCRIPTION
Remove the deprecated `babel-eslint` and replace with `@babel/eslint-parser`